### PR TITLE
metanorma/metanorma-build-scripts#66 Drop ruby 2.4 support

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         experimental: [ false ]
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,4 @@ inherit_from:
 # ...
 
 AllCops:
-  DisplayCopNames: false
-  StyleGuideCopsOnly: false
   TargetRubyVersion: 2.5


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.